### PR TITLE
Whitespace section from the ObjC style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ then open a pull request. :zap:
 
 ----
 
+#### Whitespace
+
+ * Tabs, not spaces.
+ * End files with a newline.
+ * Make liberal use of vertical whitespace to divide code into logical chunks.
+
 #### Prefer implicit getters on read-only properties and subscripts
 
 When possible, omit the `get` keyword on read-only computed properties and


### PR DESCRIPTION
Left out the trailing whitespace from https://github.com/github/objective-c-style-guide/pull/58 until we decide on that.
