### PR TITLE
Don’t leave trailing whitespace section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ then open a pull request. :zap:
  * Don’t leave trailing whitespace.
    * Not even leading indentation on blank lines.
 
+
 #### Prefer implicit getters on read-only properties and subscripts
 
 When possible, omit the `get` keyword on read-only computed properties and
@@ -75,6 +76,7 @@ internal struct TheFez {
 ```
 
 _Rationale:_ It's rarely appropriate for top-level definitions to be specifically `internal`, and being explicit ensures that careful thought goes into that decision. Within a definition, reusing the same access control specifier is just duplicative, and the default is usually reasonable.
+
 
 #### Only explicitly refer to `self` when required
 


### PR DESCRIPTION
Brings in the no trailing whitespace section from https://github.com/github/objective-c-style-guide/pull/58.
