### PR TITLE
Propose never using implicitly unwrapped optionals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,11 @@ It becomes easier to reason about code. Had you used `var` while still making th
 
 Accordingly, whenever you see a `var` identifier being used, assume that it will change and ask yourself why.
 
-#### Don't use Implicitly Unwrapped Optionals
+#### Avoid Using Implicitly Unwrapped Optionals
 
-Use `let foo: FooType?` instead of `let foo: FooType!` if foo may be nil.
+Where possible, use `let foo: FooType?` instead of `let foo: FooType!` if foo may be nil (Note that in general, `?` can be used instead of `!`).
 
-You should not ever *have* to use the exclamation mark `!` in your Swift code (i.e. it can always be replaced with `?`).
-
-_Rationale:_ Explicit optionals result in safer code. Implicitly unwrapped optionals easily lead to runtime crashes.
+_Rationale:_ Explicit optionals result in safer code. Implicitly unwrapped optionals have the potential of crashing at runtime.
 
 #### Prefer implicit getters on read-only properties and subscripts
 


### PR DESCRIPTION
This should be straightforward.

Implicitly unwrapped optionals are bad. IMHO they shouldn't exist in the language and are only a stopgap solution used by Apple while they migrate all AppKit/UIKit signatures over to explicit optionals (or no optionals).

I am not sure if this needs further explanation…?

The only place I have ever found implicitly unwrapped optionals to be somewhat OK is in conjunction with IBOutlets, but I don't know if that should be mentioned here. Thoughts?
