### PR TITLE
Propose not using force-unwrapping of optionals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ rough priority order):
 If you have suggestions, please see our [contribution guidelines](CONTRIBUTING.md),
 then open a pull request. :zap:
 
+----
 
 #### Whitespace
 


### PR DESCRIPTION
Pretty straightforward.

Force-unwrapping of optionals (either implicit or explicit) carries with it the risk of runtime crashes, which should be strongly avoided. There is hardly a reason to ever force-unwrap, and unless you really know what you're doing (and even then) it may go bad.

I personally try not to have a single exclamation mark in my code.
