### PR TITLE
Change let to var in section on implicitly unwrapped optionals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ _Rationale:_ Explicit `if let`-binding of optionals results in safer code. Force
 
 #### Avoid Using Implicitly Unwrapped Optionals
 
-Where possible, use `let foo: FooType?` instead of `let foo: FooType!` if foo may be nil (Note that in general, `?` can be used instead of `!`).
+Where possible, use `var foo: FooType?` instead of `var foo: FooType!` if foo may be nil (Note that in general, `?` can be used instead of `!`).
 
 _Rationale:_ Explicit optionals result in safer code. Implicitly unwrapped optionals have the potential of crashing at runtime.
 


### PR DESCRIPTION
Since `let` declares a constant, there is no good reason to declare a `let` variable as an optional type. That variable would always be `nil` or always be non-`nil`.