### PR TITLE
implicit type information

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,26 @@ subscript(index: Int) -> T {
 
 _Rationale:_ The intent and meaning of the first version is clear, and results in less code.
 
+#### Avoid redundant type declarations.
+
+When type information can be inferred from an initial value, avoid declaring it explicitly, unless doing so is an active decision to improve code legibility.
+
+```swift
+var isOnFire = false  // implicit Bool
+var lookupTable = [String: Int]() // implicit Dictionary<String: Int>
+var referenceFrame = CGRect(x: 0, y: 0, width: 100, height: 100) //implicit CGRect
+```
+
+instead of:
+
+```swift
+var isOnFire: Bool = false
+var lookupTable: [String: Int] = [String: Int]()
+var referenceFrame: CGRect = CGRect(x: 0, y: 0, width: 100, height: 100)
+```
+
+_Rationale_: using implicit type information results in shorter, easier to read code. 
+
 #### Always specify access control explicitly for top-level definitions
 
 Top-level functions, types, and variables should always have explicit access control specifiers:

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ subscript(index: Int) -> T {
 
 _Rationale:_ The intent and meaning of the first version is clear, and results in less code.
 
-#### Avoid redundant type declarations.
+#### Avoid redundant type declarations
 
 When type information can be inferred from an initial value, avoid declaring it explicitly, unless doing so is an active decision to improve code legibility.
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ instead of:
 var lookupTable = [Int: String]()
 var duration = NSTimeInterval(1.2)
 ```
-_Rationale_: Using implicit type information results in shorter, easier to read code. 
+_Rationale_: Avoiding redundant declarations results in shorter, easier to read code. 
 
 #### Always specify access control explicitly for top-level definitions
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ When type information can be inferred from an initial value, avoid declaring it 
 
 ```swift
 var isOnFire = false
-var lookupTable = [String: Int]()
 var referenceFrame = CGRect(x: 0, y: 0, width: 100, height: 100)
 ```
 
@@ -112,11 +111,23 @@ instead of:
 
 ```swift
 var isOnFire: Bool = false
-var lookupTable: [String: Int] = [String: Int]()
 var referenceFrame: CGRect = CGRect(x: 0, y: 0, width: 100, height: 100)
 ```
 
-_Rationale_: using implicit type information results in shorter, easier to read code. 
+When type information _cannot_ be inferred from an initial value then it should be explicitly added to the declaration; you should not add type information to a constructor for the purpose of allowing type inference.
+
+```swift
+var lookupTable: [Int: String] = [:] 
+var duration: NSTimeInterval = 1.2
+```
+
+instead of:
+
+```swift
+var lookupTable = [Int: String]()
+var duration = NSTimeInterval(1.2)
+```
+_Rationale_: Using implicit type information results in shorter, easier to read code. 
 
 #### Always specify access control explicitly for top-level definitions
 

--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ _Rationale:_ The intent and meaning of the first version is clear, and results i
 When type information can be inferred from an initial value, avoid declaring it explicitly, unless doing so is an active decision to improve code legibility.
 
 ```swift
-var isOnFire = false  // implicit Bool
-var lookupTable = [String: Int]() // implicit Dictionary<String: Int>
-var referenceFrame = CGRect(x: 0, y: 0, width: 100, height: 100) //implicit CGRect
+var isOnFire = false
+var lookupTable = [String: Int]()
+var referenceFrame = CGRect(x: 0, y: 0, width: 100, height: 100)
 ```
 
 instead of:


### PR DESCRIPTION
Was just reviewing a co-worker's PR and wanted to point them at this document as an explanation for why not to use redundant type declarations, but it wasn't in here. I thought it was?

Anyway: I think there's still a lot of ambiguity in terms of declaring vars in swift, e.g. whether we prefer `var anArray: [Int] = []` or `var anArray = [Int]()`. I prefer the latter, but it feels mostly aesthetic. 

So this is really concerned with actual redundancy. Let me know if there's anything I can do to make this clearer.
