### PR TITLE
Corrects code that would fail due to type mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ class Vehicle {
     }
 
     func maximumTotalTirePressure(pressurePerWheel: Float) -> Float {
-        return pressurePerWheel * numberOfWheels
+        return pressurePerWheel * Float(numberOfWheels)
     }
 }
 
@@ -215,7 +215,7 @@ protocol Vehicle {
 }
 
 func maximumTotalTirePressure(vehicle: Vehicle, pressurePerWheel: Float) -> Float {
-    return pressurePerWheel * vehicle.numberOfWheels
+    return pressurePerWheel * Float(vehicle.numberOfWheels)
 }
 
 struct Bicycle: Vehicle {


### PR DESCRIPTION
I know this probably seems nit-picky since this isn't a language reference, but it seems `numberOfWheels` should be converted to `Float` when doing the math here to get tire pressure. Otherwise, I'm loving this style guide!