### PR TITLE
Amend CONTRIBUTING.md to note the document’s purpose

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,6 @@
+This guide is primarily intended to be _descriptive_, detailing the usage
+that Swift developers at GitHub have arrived at in cases of disagreement.
+
 If you want to suggest a change or addition that will help accomplish
 [the goals](README.md) of this style guide, please open a pull request that:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 This guide is primarily intended to be _descriptive_, detailing the usage
 that Swift developers at GitHub have arrived at in cases of disagreement.
+Consider whether a proposed addition would make more sense in a fork used
+by your projects/organization instead.
 
 If you want to suggest a change or addition that will help accomplish
 [the goals](README.md) of this style guide, please open a pull request that:


### PR DESCRIPTION
We’ve described this document’s purpose as being descriptive rather than prescriptive in issue comments, but I noticed it’s not mentioned in `CONTRIBUTING.md`. This PR aims to amend that.