### PR TITLE
Add guideline to avoid parens in conditionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ if eventDidOccur {
 and instead of:
 
 ```swift
-for (var i = 0; i < 1; i++) {
+for (thing in setOfThings) {
     // do something
 }
 ```
@@ -225,7 +225,7 @@ for (var i = 0; i < 1; i++) {
 write:
 
 ```swift
-for var i = 0; i < 1; i++ {
+for thing in setOfThings {
     // do something
 }
 ```

--- a/README.md
+++ b/README.md
@@ -196,6 +196,42 @@ extension History {
 
 _Rationale:_ This makes the capturing semantics of `self` stand out more in closures, and avoids verbosity elsewhere.
 
+#### Avoid enclosing conditions or loop variables in parentheses
+
+When writing conditionals or loops, avoid using paretheses around your conditions or loop variables. Instead of:
+
+```swift
+if (eventDidOccur) {
+    // do something
+}
+```
+
+write:
+
+```swift
+if eventDidOccur {
+    // do something
+}
+```
+
+and instead of:
+
+```swift
+for (var i = 0; i < 1; i++) {
+    // do something
+}
+```
+
+write:
+
+```swift
+for var i = 0; i < 1; i++ {
+    // do something
+}
+```
+
+_Rationale:_ This results in conditionals and loops that are more human readable and makes it clear that if parentheses are used, it is to achieve a specific evaluation order.
+
 #### Prefer structs over classes
 
 Unless you require functionality that can only be provided by a class (like identity or deinitializers), implement a struct instead.

--- a/README.md
+++ b/README.md
@@ -196,9 +196,9 @@ extension History {
 
 _Rationale:_ This makes the capturing semantics of `self` stand out more in closures, and avoids verbosity elsewhere.
 
-#### Avoid enclosing conditions or loop variables in parentheses
+#### Avoid enclosing conditions in parentheses
 
-When writing conditionals or loops, avoid using paretheses around your conditions or loop variables. Instead of:
+When writing conditionals, avoid using paretheses around your conditions. Instead of:
 
 ```swift
 if (eventDidOccur) {
@@ -214,23 +214,7 @@ if eventDidOccur {
 }
 ```
 
-and instead of:
-
-```swift
-for (element in someArray) {
-    // do something
-}
-```
-
-write:
-
-```swift
-for element in someArray {
-    // do something
-}
-```
-
-_Rationale:_ This results in conditionals and loops that are more human readable and makes it clear that if parentheses are used, it is to achieve a specific evaluation order.
+_Rationale:_ This results in conditionals that are more human readable and makes it clear that if parentheses are used, it is to achieve a specific evaluation order.
 
 #### Prefer structs over classes
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ if eventDidOccur {
 and instead of:
 
 ```swift
-for (thing in setOfThings) {
+for (element in someArray) {
     // do something
 }
 ```
@@ -225,7 +225,7 @@ for (thing in setOfThings) {
 write:
 
 ```swift
-for thing in setOfThings {
+for element in someArray {
     // do something
 }
 ```


### PR DESCRIPTION
This is yet another area where Swift states that something is 'not required.'  While this flexibility can be powerful, it can also lead to inconsistent code - especially on larger teams.  Our team tries to adhere to the general principle of always writing the least amount of code possible and this guideline supports that.
