### PR TITLE
Translation to Brazilian Portuguese

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,3 +309,4 @@ _Rationale:_ Operators consist of punctuation characters, which can make them di
 * [日本語版](https://github.com/jarinosuke/swift-style-guide/blob/master/README_JP.md)
 * [한국어판](https://github.com/minsOne/swift-style-guide/blob/master/README_KR.md)
 * [Versión en Español](https://github.com/antoniosejas/swift-style-guide/blob/spanish/README-ES.md)
+* [Versão em Português do Brasil](https://github.com/fernandocastor/swift-style-guide/blob/master/README-PTBR.md)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ then open a pull request. :zap:
  * Don’t leave trailing whitespace.
    * Not even leading indentation on blank lines.
 
-
 #### Prefer `let`-bindings over `var`-bindings wherever possible
 
 Use `let foo = …` over `var foo = …` wherever possible (and when in doubt). Only use `var` if you absolutely have to (i.e. you *know* that the value might change, e.g. when using the `weak` storage modifier).
@@ -34,7 +33,7 @@ It becomes easier to reason about code. Had you used `var` while still making th
 
 Accordingly, whenever you see a `var` identifier being used, assume that it will change and ask yourself why.
 
-### Return and break early
+#### Return and break early
 
 When you have to meet certain criteria to continue execution, try to exit early. So, instead of this:
 
@@ -55,7 +54,6 @@ guard n.isNumber else {
 ```
 
 You can also do it with `if` statement, but using `guard` is prefered, because `guard` statement without `return`, `break` or `continue` produces a compile-time error, so exit is guaranteed.
-
 
 #### Avoid Using Force-Unwrapping of Optionals
 


### PR DESCRIPTION
I've created a translation of the guidelines for Brazilian Portuguese. I'm adding it to my fork of the repo. Furthermore, I've removed extra blank lines before two of the headers and made the title of the "Return and break early" header the same size as the others. Please accept. :)