### PR TITLE
Remove redundant leading and trailing spaces on dictionary example

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Also, when specifying the type of a dictionary, always put the colon immediately
 after the key type, followed by a space and then the value type.
 
 ```swift
-let capitals: [Country: City] = [ Sweden: Stockholm ]
+let capitals: [Country: City] = [Sweden: Stockholm]
 ```
 
 #### Only explicitly refer to `self` when required


### PR DESCRIPTION
In the section about colon position I find the following example confusing:
```
let capitals: [Country: City] = [ Sweden: Stockholm ]
```
There is no explanation why there should be a space before the dictionary key (`_Sweden`) and after the value (`Stockholm_`). I propose we remove those spaces, unless it is a desirable code style we should adopt.