### PR TITLE
Remove unwanted whitespaces and capital letters

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Also, when specifying the type of a dictionary, always put the colon immediately
 after the key type, followed by a space and then the value type.
 
 ```swift
-let capitals: [Country: City] = [ Sweden: Stockholm ]
+let capitals: [Country: City] = [sweden: stockholm]
 ```
 
 #### Only explicitly refer to `self` when required


### PR DESCRIPTION
Hello 🙂

The whitespaces after the opening bracket and before the closing one are not consistent with the brackets usage.
And the Sweden and Stockholm words should be lowercased, those are presumably instances, not types.