### PR TITLE
Use a protocol extension instead of a free function in "Prefer structs over classes"

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,10 +233,13 @@ could be refactored into these definitions:
 ```swift
 protocol Vehicle {
     var numberOfWheels: Int { get }
+    func maximumTotalTirePressure(pressurePerWheel: Float) -> Float
 }
 
-func maximumTotalTirePressure(vehicle: Vehicle, pressurePerWheel: Float) -> Float {
-    return pressurePerWheel * Float(vehicle.numberOfWheels)
+extension Vehicle {
+    func maximumTotalTirePressure(pressurePerWheel: Float) -> Float {
+    	return pressurePerWheel * Float(numberOfWheels)
+    }
 }
 
 struct Bicycle: Vehicle {


### PR DESCRIPTION
In the "Prefer structs over classes" section, the refactored implementation includes a free function, `maximumTotalTirePressure(vehicle:pressurePerWheel:)`, to replace the functionality that had been provided by a method on the superclass.

However, an alternative way of implementing this is to include `maximumTotalTirePressure(pressurePerWheel:)` as a requirement of the `Vehicle` protocol, and then provide a default implementation through a protocol extension. Using this design, calling the code is less verbose, as the function has fewer arguments. The end result is also more similar to the implementation that used classes, in that the method is called like so:

```swift
let bicycle = Bicycle()
bicycle.maximumTotalTirePressure(pressurePerWheel: 90)

let car = Car()
car.maximumTotalTirePressure(pressurePerWheel: 31)
```

...instead of being called like this:

```swift
let bicycle = Bicycle()
maximumTotalTirePressure(vehicle: bicycle: pressurePerWheel: 90)

let car = Car()
maximumTotalTirePressure(vehicle: car, pressurePerWheel: 31)
```

The intent of this code is clearer, because the method requirement on the protocol clearly states that every type conforming to `Vehicle` implements this method, instead of forcing someone who is reading the code to search for the free function that implements this functionality. In addition, types could provide their own implementation if needed.